### PR TITLE
Fix the border styles of Group component with a single child

### DIFF
--- a/packages/bumbag/src/Group/styles.ts
+++ b/packages/bumbag/src/Group/styles.ts
@@ -34,81 +34,6 @@ export const Group = styleProps => cssClass`
     ${
       styleProps.orientation === "vertical"
         ? css`
-            border-bottom-right-radius: ${borderRadius(
-              styleProps.borderRadius,
-              styleProps.borderRadius
-            )(styleProps)};
-            border-bottom-left-radius: ${borderRadius(
-              styleProps.borderRadius,
-              styleProps.borderRadius
-            )(styleProps)};
-          `
-        : css`
-            ${breakpoint(
-              styleProps.verticalBelow
-                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                : null,
-              css`
-                border-bottom-right-radius: ${borderRadius(
-                  styleProps.borderRadius,
-                  styleProps.borderRadius
-                )(styleProps)};
-                border-bottom-left-radius: ${borderRadius(
-                  styleProps.borderRadius,
-                  styleProps.borderRadius
-                )(styleProps)};
-              `,
-              {
-                else: css`
-                  border-bottom-right-radius: ${borderRadius(
-                    styleProps.borderRadius,
-                    styleProps.borderRadius
-                  )(styleProps)};
-                  border-top-right-radius: ${borderRadius(
-                    styleProps.borderRadius,
-                    styleProps.borderRadius
-                  )(styleProps)};
-                `
-              }
-            )(styleProps)};
-          `
-    }
-
-    & input,
-    & select {
-      ${
-        styleProps.orientation === "vertical"
-          ? css`
-              border-bottom-right-radius: 0;
-              border-bottom-left-radius: 0;
-            `
-          : css`
-              ${breakpoint(
-                styleProps.verticalBelow
-                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                  : null,
-                css`
-                  border-bottom-right-radius: 0;
-                  border-bottom-left-radius: 0;
-                `,
-                {
-                  else: css`
-                    border-bottom-right-radius: 0;
-                    border-top-right-radius: 0;
-                  `
-                }
-              )(styleProps)};
-            `
-      };
-    }
-
-    ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
-  }
-
-  & > *:last-child {
-    ${
-      styleProps.orientation === "vertical"
-        ? css`
             border-top-right-radius: ${borderRadius(
               styleProps.borderRadius,
               styleProps.borderRadius
@@ -124,22 +49,115 @@ export const Group = styleProps => cssClass`
                 ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
                 : null,
               css`
-                border-top-left-radius: ${borderRadius(
+                border-top-right-radius: ${borderRadius(
                   styleProps.borderRadius,
                   styleProps.borderRadius
                 )(styleProps)};
-                border-top-right-radius: ${borderRadius(
+                border-top-left-radius: ${borderRadius(
                   styleProps.borderRadius,
                   styleProps.borderRadius
                 )(styleProps)};
               `,
               {
                 else: css`
+                  border-bottom-left-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
                   border-top-left-radius: ${borderRadius(
                     styleProps.borderRadius,
                     styleProps.borderRadius
                   )(styleProps)};
+                `
+              }
+            )(styleProps)};
+          `
+    }
+
+    & input,
+    & select {
+      ${
+        styleProps.orientation === "vertical"
+          ? css`
+              border-bottom-right-radius: ${borderRadius(
+                styleProps.borderRadius,
+                styleProps.borderRadius
+              )(styleProps)};
+              border-bottom-left-radius: ${borderRadius(
+                styleProps.borderRadius,
+                styleProps.borderRadius
+              )(styleProps)};
+            `
+          : css`
+              ${breakpoint(
+                styleProps.verticalBelow
+                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                  : null,
+                css`
+                  border-bottom-right-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
                   border-bottom-left-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
+                `,
+                {
+                  else: css`
+                    border-bottom-right-radius: ${borderRadius(
+                      styleProps.borderRadius,
+                      styleProps.borderRadius
+                    )(styleProps)};
+                    border-top-right-radius: ${borderRadius(
+                      styleProps.borderRadius,
+                      styleProps.borderRadius
+                    )(styleProps)};
+                  `
+                }
+              )(styleProps)};
+            `
+      };
+    }
+
+    ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
+  }
+
+  & > *:last-child {
+    ${
+      styleProps.orientation === "vertical"
+        ? css`
+            border-bottom-right-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
+            border-bottom-left-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
+          `
+        : css`
+            ${breakpoint(
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
+              css`
+                border-bottom-left-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
+                border-bottom-right-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
+              `,
+              {
+                else: css`
+                  border-top-right-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
+                  border-bottom-right-radius: ${borderRadius(
                     styleProps.borderRadius,
                     styleProps.borderRadius
                   )(styleProps)};
@@ -174,8 +192,14 @@ export const Group = styleProps => cssClass`
       ${
         styleProps.orientation === "vertical"
           ? css`
-              border-top-left-radius: 0;
-              border-top-right-radius: 0;
+              border-top-left-radius: ${borderRadius(
+                styleProps.borderRadius,
+                styleProps.borderRadius
+              )(styleProps)};
+              border-top-right-radius: ${borderRadius(
+                styleProps.borderRadius,
+                styleProps.borderRadius
+              )(styleProps)};
             `
           : css`
               ${breakpoint(
@@ -183,13 +207,25 @@ export const Group = styleProps => cssClass`
                   ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
                   : null,
                 css`
-                  border-top-left-radius: 0;
-                  border-top-right-radius: 0;
+                  border-top-left-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
+                  border-top-right-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
                 `,
                 {
                   else: css`
-                    border-top-left-radius: 0;
-                    border-bottom-left-radius: 0;
+                    border-top-left-radius: ${borderRadius(
+                      styleProps.borderRadius,
+                      styleProps.borderRadius
+                    )(styleProps)};
+                    border-bottom-left-radius: ${borderRadius(
+                      styleProps.borderRadius,
+                      styleProps.borderRadius
+                    )(styleProps)};
                   `
                 }
               )(styleProps)};

--- a/packages/bumbag/src/Group/styles.ts
+++ b/packages/bumbag/src/Group/styles.ts
@@ -21,10 +21,6 @@ export const Group = styleProps => cssClass`
   )(styleProps)};
 
   & > * {
-    border-radius: ${borderRadius(
-      styleProps.borderRadius,
-      styleProps.borderRadius
-    )(styleProps)};
     ${theme(styleProps.themeKey, `Item.styles.base`)(styleProps)};
   }
 
@@ -34,68 +30,18 @@ export const Group = styleProps => cssClass`
     position: relative;
   }
 
-  & > *:first-child:nth-last-child(-n+1) {
-    ${
-      styleProps.orientation === "vertical"
-        ? css`
-            border-bottom-right-radius: initial;
-            border-bottom-left-radius: initial;
-          `
-        : css`
-            ${breakpoint(
-              styleProps.verticalBelow
-                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                : null,
-              css`
-                border-bottom-right-radius: initial;
-                border-bottom-left-radius: initial;
-              `,
-              {
-                else: css`
-                  border-bottom-right-radius: initial;
-                  border-top-right-radius: initial;
-                `
-              }
-            )(styleProps)};
-          `
-    }
-    & input,
-    & select {
-      ${
-        styleProps.orientation === "vertical"
-          ? css`
-              border-bottom-right-radius: initial;
-              border-bottom-left-radius: initial;
-            `
-          : css`
-              ${breakpoint(
-                styleProps.verticalBelow
-                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                  : null,
-                css`
-                  border-bottom-right-radius: initial;
-                  border-bottom-left-radius: initial;
-                `,
-                {
-                  else: css`
-                    border-bottom-right-radius: initial;
-                    border-top-right-radius: initial;
-                  `
-                }
-              )(styleProps)};
-            `
-      };
-    }
-
-    ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
-  }
-
   & > *:first-child {
     ${
       styleProps.orientation === "vertical"
         ? css`
-            border-bottom-right-radius: 0;
-            border-bottom-left-radius: 0;
+            border-bottom-right-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
+            border-bottom-left-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
           `
         : css`
             ${breakpoint(
@@ -103,13 +49,25 @@ export const Group = styleProps => cssClass`
                 ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
                 : null,
               css`
-                border-bottom-right-radius: 0;
-                border-bottom-left-radius: 0;
+                border-bottom-right-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
+                border-bottom-left-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
               `,
               {
                 else: css`
-                  border-bottom-right-radius: 0;
-                  border-top-right-radius: 0;
+                  border-bottom-right-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
+                  border-top-right-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
                 `
               }
             )(styleProps)};
@@ -147,83 +105,18 @@ export const Group = styleProps => cssClass`
     ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
   }
 
-  & > *:last-child:nth-first-child(n+1) {
-    ${
-      styleProps.orientation === "vertical"
-        ? css`
-            border-top-right-radius: initial;
-            border-top-left-radius: initial;
-          `
-        : css`
-            ${breakpoint(
-              styleProps.verticalBelow
-                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                : null,
-              css`
-                border-top-left-radius: initial;
-                border-top-right-radius: initial;
-              `,
-              {
-                else: css`
-                  border-top-left-radius: initial;
-                  border-bottom-left-radius: initial;
-                `
-              }
-            )(styleProps)};
-          `
-    }
-
-    ${breakpoint(
-      styleProps.verticalBelow
-        ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-        : null,
-      css`
-        border-top-right-radius: initial;
-        border-top-left-radius: initial;
-        border-bottom-left-radius: ${borderRadius(
-          styleProps.borderRadius,
-          styleProps.borderRadius
-        )(styleProps)};
-      `
-    )(styleProps)};
-
-    & input,
-    & select {
-      ${
-        styleProps.orientation === "vertical"
-          ? css`
-              border-top-left-radius: initial;
-              border-top-right-radius: initial;
-            `
-          : css`
-              ${breakpoint(
-                styleProps.verticalBelow
-                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
-                  : null,
-                css`
-                  border-top-left-radius: initial;
-                  border-top-right-radius: initial;
-                `,
-                {
-                  else: css`
-                    border-top-left-radius: initial;
-                    border-bottom-left-radius: initial;
-                  `
-                }
-              )(styleProps)};
-            `
-      };
-    }
-
-    ${theme(styleProps.themeKey, `Item.styles.last`)(styleProps)};
-  }
-
   & > *:last-child {
     ${
       styleProps.orientation === "vertical"
         ? css`
-            border-top-right-radius: 0;
-            border-top-left-radius: 0;
+            border-top-right-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
+            border-top-left-radius: ${borderRadius(
+              styleProps.borderRadius,
+              styleProps.borderRadius
+            )(styleProps)};
           `
         : css`
             ${breakpoint(
@@ -231,13 +124,25 @@ export const Group = styleProps => cssClass`
                 ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
                 : null,
               css`
-                border-top-left-radius: 0;
-                border-top-right-radius: 0;
+                border-top-left-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
+                border-top-right-radius: ${borderRadius(
+                  styleProps.borderRadius,
+                  styleProps.borderRadius
+                )(styleProps)};
               `,
               {
                 else: css`
-                  border-top-left-radius: 0;
-                  border-bottom-left-radius: 0;
+                  border-top-left-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
+                  border-bottom-left-radius: ${borderRadius(
+                    styleProps.borderRadius,
+                    styleProps.borderRadius
+                  )(styleProps)};
                 `
               }
             )(styleProps)};
@@ -249,8 +154,14 @@ export const Group = styleProps => cssClass`
         ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
         : null,
       css`
-        border-top-right-radius: 0;
-        border-top-left-radius: 0;
+        border-top-right-radius: ${borderRadius(
+          styleProps.borderRadius,
+          styleProps.borderRadius
+        )(styleProps)};
+        border-top-left-radius: ${borderRadius(
+          styleProps.borderRadius,
+          styleProps.borderRadius
+        )(styleProps)};
         border-bottom-left-radius: ${borderRadius(
           styleProps.borderRadius,
           styleProps.borderRadius

--- a/packages/bumbag/src/Group/styles.ts
+++ b/packages/bumbag/src/Group/styles.ts
@@ -1,25 +1,30 @@
-import { css, cssClass } from '../styled';
-import { breakpoint, borderRadius, theme } from '../utils';
+import { css, cssClass } from "../styled";
+import { breakpoint, borderRadius, theme } from "../utils";
 
 const verticalBreakpoints = {
-  tablet: 'mobile',
-  desktop: 'tablet',
-  widescreen: 'desktop',
-  fullHD: 'widescreen',
+  tablet: "mobile",
+  desktop: "tablet",
+  widescreen: "desktop",
+  fullHD: "widescreen"
 };
 
-export const Group = (styleProps) => cssClass`
-  flex-direction: ${styleProps.orientation === 'vertical' ? 'column' : 'row'};
+export const Group = styleProps => cssClass`
+  flex-direction: ${styleProps.orientation === "vertical" ? "column" : "row"};
 
   ${breakpoint(
-    styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+    styleProps.verticalBelow
+      ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+      : null,
     css`
       flex-direction: column;
     `
   )(styleProps)};
 
   & > * {
-    border-radius: ${borderRadius(styleProps.borderRadius, styleProps.borderRadius)(styleProps)};
+    border-radius: ${borderRadius(
+      styleProps.borderRadius,
+      styleProps.borderRadius
+    )(styleProps)};
     ${theme(styleProps.themeKey, `Item.styles.base`)(styleProps)};
   }
 
@@ -29,50 +34,53 @@ export const Group = (styleProps) => cssClass`
     position: relative;
   }
 
-  & > *:first-child {
+  & > *:first-child:nth-last-child(-n+1) {
     ${
-      styleProps.orientation === 'vertical'
+      styleProps.orientation === "vertical"
         ? css`
-            border-bottom-right-radius: 0;
-            border-bottom-left-radius: 0;
+            border-bottom-right-radius: initial;
+            border-bottom-left-radius: initial;
           `
         : css`
             ${breakpoint(
-              styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
               css`
-                border-bottom-right-radius: 0;
-                border-bottom-left-radius: 0;
+                border-bottom-right-radius: initial;
+                border-bottom-left-radius: initial;
               `,
               {
                 else: css`
-                  border-bottom-right-radius: 0;
-                  border-top-right-radius: 0;
-                `,
+                  border-bottom-right-radius: initial;
+                  border-top-right-radius: initial;
+                `
               }
             )(styleProps)};
           `
     }
-
     & input,
     & select {
       ${
-        styleProps.orientation === 'vertical'
+        styleProps.orientation === "vertical"
           ? css`
-              border-bottom-right-radius: 0;
-              border-bottom-left-radius: 0;
+              border-bottom-right-radius: initial;
+              border-bottom-left-radius: initial;
             `
           : css`
               ${breakpoint(
-                styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+                styleProps.verticalBelow
+                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                  : null,
                 css`
-                  border-bottom-right-radius: 0;
-                  border-bottom-left-radius: 0;
+                  border-bottom-right-radius: initial;
+                  border-bottom-left-radius: initial;
                 `,
                 {
                   else: css`
-                    border-bottom-right-radius: 0;
-                    border-top-right-radius: 0;
-                  `,
+                    border-bottom-right-radius: initial;
+                    border-top-right-radius: initial;
+                  `
                 }
               )(styleProps)};
             `
@@ -82,16 +90,146 @@ export const Group = (styleProps) => cssClass`
     ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
   }
 
+  & > *:first-child {
+    ${
+      styleProps.orientation === "vertical"
+        ? css`
+            border-bottom-right-radius: 0;
+            border-bottom-left-radius: 0;
+          `
+        : css`
+            ${breakpoint(
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
+              css`
+                border-bottom-right-radius: 0;
+                border-bottom-left-radius: 0;
+              `,
+              {
+                else: css`
+                  border-bottom-right-radius: 0;
+                  border-top-right-radius: 0;
+                `
+              }
+            )(styleProps)};
+          `
+    }
+
+    & input,
+    & select {
+      ${
+        styleProps.orientation === "vertical"
+          ? css`
+              border-bottom-right-radius: 0;
+              border-bottom-left-radius: 0;
+            `
+          : css`
+              ${breakpoint(
+                styleProps.verticalBelow
+                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                  : null,
+                css`
+                  border-bottom-right-radius: 0;
+                  border-bottom-left-radius: 0;
+                `,
+                {
+                  else: css`
+                    border-bottom-right-radius: 0;
+                    border-top-right-radius: 0;
+                  `
+                }
+              )(styleProps)};
+            `
+      };
+    }
+
+    ${theme(styleProps.themeKey, `Item.styles.first`)(styleProps)};
+  }
+
+  & > *:last-child:nth-first-child(n+1) {
+    ${
+      styleProps.orientation === "vertical"
+        ? css`
+            border-top-right-radius: initial;
+            border-top-left-radius: initial;
+          `
+        : css`
+            ${breakpoint(
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
+              css`
+                border-top-left-radius: initial;
+                border-top-right-radius: initial;
+              `,
+              {
+                else: css`
+                  border-top-left-radius: initial;
+                  border-bottom-left-radius: initial;
+                `
+              }
+            )(styleProps)};
+          `
+    }
+
+    ${breakpoint(
+      styleProps.verticalBelow
+        ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+        : null,
+      css`
+        border-top-right-radius: initial;
+        border-top-left-radius: initial;
+        border-bottom-left-radius: ${borderRadius(
+          styleProps.borderRadius,
+          styleProps.borderRadius
+        )(styleProps)};
+      `
+    )(styleProps)};
+
+    & input,
+    & select {
+      ${
+        styleProps.orientation === "vertical"
+          ? css`
+              border-top-left-radius: initial;
+              border-top-right-radius: initial;
+            `
+          : css`
+              ${breakpoint(
+                styleProps.verticalBelow
+                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                  : null,
+                css`
+                  border-top-left-radius: initial;
+                  border-top-right-radius: initial;
+                `,
+                {
+                  else: css`
+                    border-top-left-radius: initial;
+                    border-bottom-left-radius: initial;
+                  `
+                }
+              )(styleProps)};
+            `
+      };
+    }
+
+    ${theme(styleProps.themeKey, `Item.styles.last`)(styleProps)};
+  }
+
   & > *:last-child {
     ${
-      styleProps.orientation === 'vertical'
+      styleProps.orientation === "vertical"
         ? css`
             border-top-right-radius: 0;
             border-top-left-radius: 0;
           `
         : css`
             ${breakpoint(
-              styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
               css`
                 border-top-left-radius: 0;
                 border-top-right-radius: 0;
@@ -100,32 +238,39 @@ export const Group = (styleProps) => cssClass`
                 else: css`
                   border-top-left-radius: 0;
                   border-bottom-left-radius: 0;
-                `,
+                `
               }
             )(styleProps)};
           `
     }
 
     ${breakpoint(
-      styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+      styleProps.verticalBelow
+        ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+        : null,
       css`
         border-top-right-radius: 0;
         border-top-left-radius: 0;
-        border-bottom-left-radius: ${borderRadius(styleProps.borderRadius, styleProps.borderRadius)(styleProps)};
+        border-bottom-left-radius: ${borderRadius(
+          styleProps.borderRadius,
+          styleProps.borderRadius
+        )(styleProps)};
       `
     )(styleProps)};
 
     & input,
     & select {
       ${
-        styleProps.orientation === 'vertical'
+        styleProps.orientation === "vertical"
           ? css`
               border-top-left-radius: 0;
               border-top-right-radius: 0;
             `
           : css`
               ${breakpoint(
-                styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+                styleProps.verticalBelow
+                  ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                  : null,
                 css`
                   border-top-left-radius: 0;
                   border-top-right-radius: 0;
@@ -134,7 +279,7 @@ export const Group = (styleProps) => cssClass`
                   else: css`
                     border-top-left-radius: 0;
                     border-bottom-left-radius: 0;
-                  `,
+                  `
                 }
               )(styleProps)};
             `
@@ -153,20 +298,22 @@ export const Group = (styleProps) => cssClass`
 
   & > *:not(:first-child) {
     ${
-      styleProps.orientation === 'vertical'
+      styleProps.orientation === "vertical"
         ? css`
             border-top-width: 0;
           `
         : css`
             ${breakpoint(
-              styleProps.verticalBelow ? `max-${verticalBreakpoints[styleProps.verticalBelow]}` : null,
+              styleProps.verticalBelow
+                ? `max-${verticalBreakpoints[styleProps.verticalBelow]}`
+                : null,
               css`
                 border-top-width: 0;
               `,
               {
                 else: css`
                   border-left-width: 0;
-                `,
+                `
               }
             )(styleProps)};
           `


### PR DESCRIPTION
Found the reason for it: https://github.com/bumbag/bumbag-ui/blob/f3c27d0a16e1ccda569a9d7bb41bf97164fabb93/packages/bumbag/src/Group/styles.ts#L32

The reason is that there is only one child so all 4 borders get removed because `:first-child` and `:last-child` both match if there is only one child.

This SO answer has a good way to solve this: https://stackoverflow.com/a/12198561

I also prepared a codepen to see the plain combination of CSS selectors I used:
https://codepen.io/darksmile92/pen/918d944b148508069fba407bc2c06ce3

This is my first contribution to your codebase, please let me know if I should fix any styling or something else :)

Sorry for the mess with the quotes, sublime decided the roll its own linting -.-