### PR TITLE
Fix sidebar scroll state being lost between pages

### DIFF
--- a/packages/website/gatsby-browser.js
+++ b/packages/website/gatsby-browser.js
@@ -12,3 +12,7 @@ import ElementWrapper from './src/layout/ElementWrapper';
 export const wrapRootElement = (props) => {
   return <ElementWrapper {...props} />;
 };
+
+export const replaceComponentRenderer = ({props}) => {
+  return React.createElement(props.pageResources.component, props)
+}


### PR DESCRIPTION
Fixes #11 

It looks like Gatsby's default page renderer [sets a key for each page](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/cache-dir/page-renderer.js#L23), so React is forced to rebuild the entire tree when changing pages. Container scroll state, like in the sidebar, is lost as a result.

I've replaced the default page renderer with one that doesn't set a key, so the diffing can be left up to React.

Glancing at Gatsby's history, I think the key might have been introduced to React [play nicely with other plugins that alter the DOM](https://github.com/gatsbyjs/gatsby/issues/8181) (like Twitter widgets). So long as this isn't necessary for the Bumbag docs, this change should be all good!

Cheers, Nicholas :shipit: 