### PR TITLE
Prevent Horizontal Scroll in the Docs

### DIFF
--- a/packages/website/src/theme/index.js
+++ b/packages/website/src/theme/index.js
@@ -42,6 +42,10 @@ export default {
   global: {
     styles: {
       base: css`
+        html, body {
+          overflow-x: hidden;
+        }
+
         a.anchor {
           opacity: 0;
           position: absolute;


### PR DESCRIPTION
Ensures that pages in the docs don't scroll horizontally (which is particularly visible in some viewports on the homepage)