### PR TITLE
Add 'Skip to Main Content' button to docs page

### DIFF
--- a/packages/website/src/components/Header.tsx
+++ b/packages/website/src/components/Header.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, Hide, TopNav, Icon, Image, useColorMode, usePage, useTheme } from 'bumbag';
 import { FeedbackForm } from 'feedback-fish';
 import { Link, useLocation } from '@reach/router';
+import SkipToMainContent from './SkipToMainContent';
 
 import ColorModePicker from './ColorModePicker';
 
@@ -39,6 +40,7 @@ export default function Header(props) {
         <TopNav.Item href="/" fontWeight="semibold">
           {Logo}
         </TopNav.Item>
+        {pathname !== '/' && <SkipToMainContent />}
         <TopNav.Item use={Link} navId="docs" to="/getting-started" fontWeight="semibold">
           Docs
         </TopNav.Item>

--- a/packages/website/src/components/SkipToMainContent.tsx
+++ b/packages/website/src/components/SkipToMainContent.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react';
+import { Button, styled } from 'bumbag';
+
+const SkipToMainContentButton = styled(Button)`
+  position: fixed;
+  top: -100%;
+  left: -100%;
+  &:focus {
+    top: 7px;
+    left: 7px;
+  }
+`;
+
+const SkipToMainContent = () => {
+  return (
+    <SkipToMainContentButton
+      use="a"
+      href="#main-content"
+    >
+      Skip to Main Content
+    </SkipToMainContentButton>
+  )
+}
+
+export default SkipToMainContent;

--- a/packages/website/src/layout/DocsLayout.tsx
+++ b/packages/website/src/layout/DocsLayout.tsx
@@ -142,7 +142,7 @@ export default function Docs(props: Props) {
           {pageContext.tableOfContents && (
             <TableOfContents breakpoint={breakpoint} isFluid={isFluid} toc={pageContext.tableOfContents} />
           )}
-          <bumbag.PageContent isLayout={isFluid} isFluid={isFluid} breakpoint={breakpoint}>
+          <bumbag.PageContent isLayout={isFluid} isFluid={isFluid} breakpoint={breakpoint} use="main" id="main-content">
             {pageContext.mdxBody ? (
               <MDXProvider components={components}>
                 <MDXRenderer>{pageContext.mdxBody}</MDXRenderer>


### PR DESCRIPTION
This PR addresses the keyboard accessibility problem outlined in issue #14. Starting at the URL bar, the first tabbed element is still the link to the Bumbag home page, but tabbing again allows users to skip to the main content via a button/link that pops up only when focused:
![image](https://user-images.githubusercontent.com/9068746/95004696-497b4680-05b4-11eb-895f-759195dcdee6.png)
The main content area was given an id of "main-content", and the button links to that, skipping the header and sidebar.