### PR TITLE
Fix: Don't show clear button on disabled autosuggest

### DIFF
--- a/packages/bumbag/src/Autosuggest/Autosuggest.tsx
+++ b/packages/bumbag/src/Autosuggest/Autosuggest.tsx
@@ -598,6 +598,10 @@ const useProps = createHook<AutosuggestProps>(
 
     //////////////////////////////////////////////////
 
+    const showClearButton = inputValue && !disabled;
+
+    //////////////////////////////////////////////////
+
     return {
       ...boxProps,
       'aria-expanded': dropdownMenuButtonProps['aria-expanded'],
@@ -609,7 +613,7 @@ const useProps = createHook<AutosuggestProps>(
         <AutosuggestContext.Provider value={context}>
           <Input
             {...omit(dropdownMenuButtonProps, 'type', 'className', 'role')}
-            after={inputValue && <ClearButton onClick={handleClear} buttonProps={clearButtonProps} />}
+            after={showClearButton && <ClearButton onClick={handleClear} buttonProps={clearButtonProps} />}
             aria-autocomplete="list"
             aria-activedescendant={dropdownMenu?.items?.[highlightedIndex]?.id}
             className={inputClassName}


### PR DESCRIPTION
Currently, if the Autosuggest is disabled, the clear button is still shown and the user is able to clear the input. This PR hides the clear button if the input is disabled, and therefore stops users from being able to change the input value.