### PR TITLE
Enhancement: autofocus select menu search input

### DIFF
--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -478,6 +478,7 @@ const useProps = createHook<SelectMenuProps>(
                     onChange={handleChangeInput}
                     value={searchText}
                     searchInputProps={searchInputProps}
+                    autoFocus={isDropdown}
                   />
                 )}
                 {hasTags && selectedOptions.length > 0 && (
@@ -670,7 +671,7 @@ function SelectMenuButton(props: any) {
 //////////////////////////////////////////////////////////////////
 
 function SelectMenuSearchInput(props: any) {
-  const { onChange, searchInputProps, value, ...restProps } = props;
+  const { autoFocus, onChange, searchInputProps, value, ...restProps } = props;
 
   const { overrides, themeKey } = React.useContext(SelectMenuContext);
 
@@ -695,6 +696,7 @@ function SelectMenuSearchInput(props: any) {
         overrides={overrides}
         placeholder="Type to search..."
         value={value}
+        autoFocus={autoFocus}
         {...searchInputProps}
       />
     </Box>


### PR DESCRIPTION
Fannypack used to autofocus the search input on the select menu. This PR implements the same functionality for the Bumbag select menu. It will not autofocus the search input if the `isDropdown` prop is `false`. 