### PR TITLE
Allow null for verticalBreakpoint on <Level />

### DIFF
--- a/packages/bumbag/src/Level/Level.tsx
+++ b/packages/bumbag/src/Level/Level.tsx
@@ -11,8 +11,8 @@ export type LocalLevelProps = {
   orientation?: 'vertical' | 'horizontal';
   /** Sets the spacing of the level when it snaps to a vertical orientation. */
   spacing?: string;
-  /** Sets the breakpoint at which the level should become vertical. */
-  verticalBelow?: Breakpoint;
+  /** Sets the breakpoint at which the level should become vertical; null to disable vertical snapping. */
+  verticalBelow?: Breakpoint | null;
 };
 export type LevelProps = FlexProps & LocalLevelProps;
 


### PR DESCRIPTION
The docs say to set `verticalBreakpoint` on `Level` components to `null` to disable vertical snapping, but the values can only be `Breakpoint` or `undefined`.

See: https://bumbag.style/layout/level/#vertical-breakpoint

<img width="215" alt="CleanShot 2021-03-05 at 14 02 03@2x" src="https://user-images.githubusercontent.com/81990/110125599-64e4ba80-7dbb-11eb-9f21-8cb51d85a916.png">