### PR TITLE
Fix for darkmode docs palette colour

### DIFF
--- a/packages/website/src/components/ColorModePicker.tsx
+++ b/packages/website/src/components/ColorModePicker.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { useLocation, useNavigate } from '@reach/router';
-import { Box, Button, Icon, useColorMode } from 'bumbag';
+import * as React from "react";
+import { useLocation, useNavigate } from "@reach/router";
+import { Box, Button, Icon, useColorMode } from "bumbag";
 
 export default function ColorModePicker(props) {
   const { colorMode, setColorMode } = useColorMode();
@@ -15,14 +15,32 @@ export default function ColorModePicker(props) {
 
   return (
     <Box>
-      {colorMode === 'default' && (
-        <Button onClick={() => setColorMode('dark')} color="gray" variant="ghost">
-          <Icon icon="solid-moon" />
+      {colorMode === "default" && (
+        <Button
+          onClick={() => setColorMode("dark")}
+          color="gray"
+          iconAfter={props.labeled ? "solid-moon" : null}
+          variant={props.labeled ? null : "ghost"}
+        >
+          {props.labeled ? (
+            "Change to Dark Color Mode"
+          ) : (
+            <Icon icon="solid-moon" />
+          )}
         </Button>
       )}
-      {colorMode === 'dark' && (
-        <Button onClick={() => setColorMode('default')} color="text" variant="ghost">
-          <Icon icon="solid-sun" />
+      {colorMode === "dark" && (
+        <Button
+          onClick={() => setColorMode("default")}
+          color="text"
+          iconAfter={props.labeled ? "solid-sun" : null}
+          variant={props.labeled ? null : "ghost"}
+        >
+          {props.labeled ? (
+            "Change to Default Color Mode"
+          ) : (
+            <Icon icon="solid-sun" />
+          )}
         </Button>
       )}
     </Box>

--- a/packages/website/src/components/ColorModePicker.tsx
+++ b/packages/website/src/components/ColorModePicker.tsx
@@ -1,43 +1,34 @@
-import * as React from "react";
-import { useLocation, useNavigate } from "@reach/router";
-import { Box, Button, Icon, useColorMode } from "bumbag";
+import * as React from 'react';
+import { Box, Button, Icon, useColorMode } from 'bumbag';
 
 export default function ColorModePicker(props) {
   const { colorMode, setColorMode } = useColorMode();
 
-  const handleChangeTheme = React.useCallback(
-    (e) => {
-      const colorMode = e.target.value;
-      setColorMode(colorMode);
-    },
-    [setColorMode]
-  );
-
   return (
     <Box>
-      {colorMode === "default" && (
+      {colorMode === 'default' && (
         <Button
-          onClick={() => setColorMode("dark")}
+          onClick={() => setColorMode('dark')}
           color="gray"
-          iconAfter={props.labeled ? "solid-moon" : null}
-          variant={props.labeled ? null : "ghost"}
+          iconAfter={props.labeled ? 'solid-moon' : null}
+          variant={props.labeled ? null : 'ghost'}
         >
           {props.labeled ? (
-            "Change to Dark Color Mode"
+            'Change to Dark Color Mode'
           ) : (
             <Icon icon="solid-moon" />
           )}
         </Button>
       )}
-      {colorMode === "dark" && (
+      {colorMode === 'dark' && (
         <Button
-          onClick={() => setColorMode("default")}
-          color="text"
-          iconAfter={props.labeled ? "solid-sun" : null}
-          variant={props.labeled ? null : "ghost"}
+          onClick={() => setColorMode('default')}
+          color='text'
+          iconAfter={props.labeled ? 'solid-sun' : null}
+          variant={props.labeled ? null : 'ghost'}
         >
           {props.labeled ? (
-            "Change to Default Color Mode"
+            'Change to Default Color Mode'
           ) : (
             <Icon icon="solid-sun" />
           )}

--- a/packages/website/src/components/PaletteColor.tsx
+++ b/packages/website/src/components/PaletteColor.tsx
@@ -1,12 +1,12 @@
-import React from "react";
-import { Box, Button, Flex, Text, useTheme, useColorMode } from "bumbag";
+import React from 'react';
+import { Box, Button, Flex, Text, useTheme, useColorMode } from 'bumbag';
 
 const PaletteColor = ({ palette, ...props }: any) => {
   const { theme } = useTheme();
   const { colorMode } = useColorMode();
 
   const colorModePalette =
-    colorMode === "dark" && theme.palette.modes.dark[palette]
+    colorMode === 'dark' && theme.palette.modes.dark[palette]
       ? theme.palette.modes.dark[palette]
       : theme.palette[palette];
 

--- a/packages/website/src/components/PaletteColor.tsx
+++ b/packages/website/src/components/PaletteColor.tsx
@@ -1,20 +1,31 @@
-import React from 'react';
-import { Box, Button, Flex, Text, useTheme } from 'bumbag';
+import React from "react";
+import { Box, Button, Flex, Text, useTheme, useColorMode } from "bumbag";
 
 const PaletteColor = ({ palette, ...props }: any) => {
   const { theme } = useTheme();
+  const { colorMode } = useColorMode();
+
+  const colorModePalette =
+    colorMode === "dark" && theme.palette.modes.dark[palette]
+      ? theme.palette.modes.dark[palette]
+      : theme.palette[palette];
 
   return (
     <Box border="default" borderColor="white800">
       <Flex flexDirection="column">
-        <Box height="60px" backgroundColor={palette} width="100%" {...props} />
+        <Box
+          height="60px"
+          backgroundColor={colorModePalette}
+          width="100%"
+          {...props}
+        />
         <Box padding="minor-2" lineHeight="none">
           <Text fontSize="150" marginBottom="minor-1">
             {palette}
           </Text>
           <br />
           <Text color="text100" fontSize="100">
-            {theme.palette[palette]}
+            {colorModePalette}
           </Text>
         </Box>
       </Flex>

--- a/packages/website/src/docs/palette.mdx
+++ b/packages/website/src/docs/palette.mdx
@@ -20,109 +20,51 @@ The [color mode](/color-modes) of the theme defines the selected palette.
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="default" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="default" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="text400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="text300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="text200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="text100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="text" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="textTint" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="textTint" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primaryTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primaryShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primaryTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primaryShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="primary900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary900" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondaryTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondaryShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondaryTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondaryShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="secondary900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary900" /></Columns.Column>
   </Columns>
 </Box>
 
@@ -130,75 +72,37 @@ The [color mode](/color-modes) of the theme defines the selected palette.
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="black" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="black400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="black300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="black200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="black100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black100" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="white" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="white600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="white700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="white800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="white900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white900" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="gray900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray900" /></Columns.Column>
   </Columns>
 </Box>
 
@@ -206,160 +110,72 @@ The [color mode](/color-modes) of the theme defines the selected palette.
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="infoTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="infoShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="infoTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="infoShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="info900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info900" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="successTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="successShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="successTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="successShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="success900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success900" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="dangerTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="dangerShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="dangerTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="dangerShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="danger900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger900" /></Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning400" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning300" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning200" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning100" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning400" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning300" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning200" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning100" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warningTint" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warningShade" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warningTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warningShade" /></Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning600" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning700" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning800" />
-    </Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}>
-      <PaletteColor palette="warning900" />
-    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning600" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning700" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning800" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning900" /></Columns.Column>
   </Columns>
 </Box>
 
@@ -388,13 +204,13 @@ const PrimaryButton = applyTheme(Button, {
 #### `styled`
 
 ```jsx
-import { Button, styled, palette } from "bumbag";
+import { Button, styled, palette } from 'bumbag';
 
 const PrimaryButton = styled(Button)`
-  color: ${palette("primary")};
+  color: ${palette('primary')}
 `;
 
-<PrimaryButton>I am a primary button</PrimaryButton>;
+<PrimaryButton>I am a primary button</PrimaryButton>
 ```
 
 ### Within CSS Props
@@ -402,9 +218,9 @@ const PrimaryButton = styled(Button)`
 Any CSS color attribute (e.g. `color`, `borderColor`, etc) can take a color from the palette:
 
 ```jsx
-import { Text } from "bumbag";
+import { Text } from 'bumbag';
 
-<Text color="primary">I am a primary text</Text>;
+<Text color="primary">I am a primary text</Text>
 ```
 
 ## Modifying the palette

--- a/packages/website/src/docs/palette.mdx
+++ b/packages/website/src/docs/palette.mdx
@@ -4,62 +4,125 @@ title: Palette
 path: /palette/
 ---
 
-import { Box, Columns } from 'bumbag';
-import PaletteColor from '../components/PaletteColor';
+import { Box, Columns, Button } from "bumbag";
+import PaletteColor from "../components/PaletteColor";
+import ColorModePicker from "../components/ColorModePicker";
 
 # Palette
 
-Bumbag provides an accessible default palette to get you up and running, hopefully you like it. If not, feel free to customize it.
+Bumbag provides accessible default and dark palettes to get you up and running, hopefully you like it. If not, feel free to customize it.
+
+The [color mode](/color-modes) of the theme defines the selected palette.
+
+<ColorModePicker labeled />
 
 ### Defaults
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="default" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="default" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="text400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="text300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="text200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="text100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="text" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="textTint" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="text" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="textTint" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primaryTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primaryShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primaryTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primaryShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="primary900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="primary900" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondaryTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondaryShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondaryTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondaryShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="secondary900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="secondary900" />
+    </Columns.Column>
   </Columns>
 </Box>
 
@@ -67,37 +130,75 @@ Bumbag provides an accessible default palette to get you up and running, hopeful
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="black" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="black100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="black400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="black300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="black200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="black100" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="white" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="white900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="white600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="white700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="white800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="white900" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="gray900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="gray900" />
+    </Columns.Column>
   </Columns>
 </Box>
 
@@ -105,72 +206,160 @@ Bumbag provides an accessible default palette to get you up and running, hopeful
 
 <Box marginBottom="major-7">
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="infoTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="infoShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="infoTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="infoShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="info900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="info900" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="successTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="successShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="successTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="successShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="success900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="success900" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="dangerTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="dangerShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="dangerTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="dangerShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="danger900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="danger900" />
+    </Columns.Column>
   </Columns>
   <Columns marginTop="major-4">
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning400" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning300" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning200" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning100" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning400" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning300" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning200" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning100" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warningTint" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warningShade" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warningTint" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warningShade" />
+    </Columns.Column>
   </Columns>
   <Columns>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning600" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning700" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning800" /></Columns.Column>
-    <Columns.Column spread={3} spreadMobile={6}><PaletteColor palette="warning900" /></Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning600" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning700" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning800" />
+    </Columns.Column>
+    <Columns.Column spread={3} spreadMobile={6}>
+      <PaletteColor palette="warning900" />
+    </Columns.Column>
   </Columns>
 </Box>
 
@@ -199,13 +388,13 @@ const PrimaryButton = applyTheme(Button, {
 #### `styled`
 
 ```jsx
-import { Button, styled, palette } from 'bumbag';
+import { Button, styled, palette } from "bumbag";
 
 const PrimaryButton = styled(Button)`
-  color: ${palette('primary')}
+  color: ${palette("primary")};
 `;
 
-<PrimaryButton>I am a primary button</PrimaryButton>
+<PrimaryButton>I am a primary button</PrimaryButton>;
 ```
 
 ### Within CSS Props
@@ -213,9 +402,9 @@ const PrimaryButton = styled(Button)`
 Any CSS color attribute (e.g. `color`, `borderColor`, etc) can take a color from the palette:
 
 ```jsx
-import { Text } from 'bumbag';
+import { Text } from "bumbag";
 
-<Text color="primary">I am a primary text</Text>
+<Text color="primary">I am a primary text</Text>;
 ```
 
 ## Modifying the palette


### PR DESCRIPTION
So I've updated the Palette page to reflect the colour mode of the docs site. I've added a button so it's easy to toggle, and a bit more info about colour modes.

I don't know if the way I'm accessing the dark colours makes sense? But it works!