### PR TITLE
fix: select menu search

### DIFF
--- a/packages/bumbag-theme-medipass/src/fontWeights.ts
+++ b/packages/bumbag-theme-medipass/src/fontWeights.ts
@@ -1,5 +1,5 @@
 export default {
   normal: 400,
   semibold: 700,
-  bold: 900
+  bold: 900,
 };

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -202,7 +202,7 @@ const useProps = createHook<SelectMenuProps>(
       isFocused,
       inputProps: { onBlur, onChange, onFocus },
     } = useLabelPlaceholder({
-      enabled: true,
+      enabled: Boolean(label),
       useValue: true,
       onBlur: null,
       onFocus: null,

--- a/packages/bumbag/src/SelectMenu/SelectMenu.tsx
+++ b/packages/bumbag/src/SelectMenu/SelectMenu.tsx
@@ -171,6 +171,7 @@ const useProps = createHook<SelectMenuProps>(
       tagProps,
       value,
       variant,
+      onChange: _onChange,
       ...restProps
     } = props;
 
@@ -201,10 +202,11 @@ const useProps = createHook<SelectMenuProps>(
       isFocused,
       inputProps: { onBlur, onChange, onFocus },
     } = useLabelPlaceholder({
-      enabled: Boolean(label),
+      enabled: true,
       useValue: true,
       onBlur: null,
       onFocus: null,
+      onChange: _onChange,
       ...props,
     });
 
@@ -828,16 +830,24 @@ function MatchedLabel(props: { label: string; searchText: string; overrides: any
 
   return highlightedText ? (
     <Text className={className} overrides={overrides} {...restProps}>
-      {preText && <Text overrides={overrides}>{preText}</Text>}
+      {preText && (
+        <Text fontWeight="normal" overrides={overrides}>
+          {preText}
+        </Text>
+      )}
       {highlightedText && (
         <Text fontWeight="semibold" overrides={overrides}>
           {highlightedText}
         </Text>
       )}
-      {postText && <Text overrides={overrides}>{postText}</Text>}
+      {postText && (
+        <Text fontWeight="normal" overrides={overrides}>
+          {postText}
+        </Text>
+      )}
     </Text>
   ) : (
-    <Text className={className} overrides={overrides} {...restProps}>
+    <Text fontWeight="normal" className={className} overrides={overrides} {...restProps}>
       {label}
     </Text>
   );


### PR DESCRIPTION
This PR fixes two issues:

## 1. Select menu search
At the moment, and since this commit (https://github.com/bumbag/bumbag-ui/commit/9c371e490028ebeefd03f8f2e5ef4cb928a46c24), the select menu search has been broken such that typing anything into the search box will result in an `undefined` item being selected.

### Before
![image](https://user-images.githubusercontent.com/40446421/124051269-8602a280-da5f-11eb-8bb7-59f8a4e40eaf.png)

### After with PR fix
![image](https://user-images.githubusercontent.com/40446421/124051250-7be0a400-da5f-11eb-911b-987a1b53a981.png)


## 2. Select menu item label font weights
The select menu font weights are a bit out of whack on the Medipass theme.

### Before
![image](https://user-images.githubusercontent.com/40446421/124051129-3c19bc80-da5f-11eb-98d1-56fb2a8504ca.png)

### After with PR fix
![image](https://user-images.githubusercontent.com/40446421/124051420-d843c380-da5f-11eb-8a2d-4bfa7759222c.png)
