### PR TITLE
fix: google fonts on safari

### DIFF
--- a/packages/bumbag/package.json
+++ b/packages/bumbag/package.json
@@ -19,6 +19,7 @@
     "jest": "BUMBAG_ENV=test jest"
   },
   "dependencies": {
+    "@emotion/core": "npm:@bumbag/emotion-core@10.1.1-4",
     "@emotion/css": "npm:@bumbag/emotion-css@11.1.3-1",
     "@emotion/is-prop-valid": "0.8.2",
     "@emotion/react": "npm:@bumbag/emotion-react@11.1.5-2",

--- a/packages/bumbag/src/styled/index.ts
+++ b/packages/bumbag/src/styled/index.ts
@@ -1,4 +1,5 @@
 export { default as classNames } from 'classnames';
+export { Global } from '@emotion/core';
 export { flush, hydrate, cx, getRegisteredStyles, injectGlobal, sheet, css as cssClass, cache } from '@emotion/css';
-export { css, keyframes, Global, ThemeContext, CacheProvider, withTheme, ThemeProvider } from '@emotion/react';
+export { css, keyframes, ThemeContext, CacheProvider, withTheme, ThemeProvider } from '@emotion/react';
 export { default as styled } from '@emotion/styled';

--- a/packages/bumbag/src/types/css.ts
+++ b/packages/bumbag/src/types/css.ts
@@ -1,4 +1,14 @@
-import { Altitude, BorderRadii, FontFamily, FontSize, FontWeight, GradientDirection, LetterSpacing, LineHeight, Palette } from './props';
+import {
+  Altitude,
+  BorderRadii,
+  FontFamily,
+  FontSize,
+  FontWeight,
+  GradientDirection,
+  LetterSpacing,
+  LineHeight,
+  Palette,
+} from './props';
 import { Flexible } from './utils';
 
 export type CSSProperties = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1318,6 +1318,16 @@
     find-root "^1.1.0"
     source-map "^0.7.2"
 
+"@emotion/cache@npm:@bumbag/emotion-cache@10.0.29-2":
+  version "10.0.29-2"
+  resolved "https://registry.yarnpkg.com/@bumbag/emotion-cache/-/emotion-cache-10.0.29-2.tgz#f7dda63caf41041d482ab477ec0d91153fb0fac2"
+  integrity sha512-A6CnoRWe2iMiEd4JuYApKxUbZNonrU/2LYVMu3aD+1DbysG6b9xW1TOseV/w5G7iHvf4CWmpDPfYGVEF2IVbQw==
+  dependencies:
+    "@emotion/sheet" "0.9.4"
+    "@emotion/stylis" "0.8.5"
+    "@emotion/utils" "0.11.3"
+    "@emotion/weak-memoize" "0.2.5"
+
 "@emotion/cache@npm:@bumbag/emotion-cache@11.1.3-1":
   version "11.1.3-1"
   resolved "https://registry.yarnpkg.com/@bumbag/emotion-cache/-/emotion-cache-11.1.3-1.tgz#76048f71675be5ae9bff763e6ff8130c55af9d32"
@@ -1329,6 +1339,18 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "^4.0.3"
 
+"@emotion/core@npm:@bumbag/emotion-core@10.1.1-4":
+  version "10.1.1-4"
+  resolved "https://registry.yarnpkg.com/@bumbag/emotion-core/-/emotion-core-10.1.1-4.tgz#7994640d076591cd6e89699e027ad4e52ebcd49d"
+  integrity sha512-AyAw9HxLMkKNZsACOaO7+bXllOkfua2mk0RYLxxir42pKw6d1iGht2JqpPBeJ7wu64s8hHMWKErRiQqmfeS9rg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    "@emotion/cache" "npm:@bumbag/emotion-cache@10.0.29-2"
+    "@emotion/css" "^10.0.27"
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/sheet" "0.9.4"
+    "@emotion/utils" "0.11.3"
+
 "@emotion/css-prettifier@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz#3ed4240d93c9798c001cedf27dd0aa960bdddd1a"
@@ -1336,6 +1358,15 @@
   dependencies:
     "@emotion/memoize" "^0.7.4"
     stylis "^4.0.3"
+
+"@emotion/css@^10.0.27":
+  version "10.0.27"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
+  integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
+  dependencies:
+    "@emotion/serialize" "^0.11.15"
+    "@emotion/utils" "0.11.3"
+    babel-plugin-emotion "^10.0.27"
 
 "@emotion/css@npm:@bumbag/emotion-css@11.1.3-1":
   version "11.1.3-1"
@@ -1441,7 +1472,7 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/serialize@^0.11.16":
+"@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
   integrity sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==
@@ -1472,6 +1503,11 @@
     multipipe "^1.0.2"
     through "^2.3.8"
 
+"@emotion/sheet@0.9.4":
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
+  integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
 "@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
@@ -1487,6 +1523,11 @@
     "@emotion/is-prop-valid" "^1.1.0"
     "@emotion/serialize" "^1.0.0"
     "@emotion/utils" "^1.0.0"
+
+"@emotion/stylis@0.8.5":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
 "@emotion/stylis@^0.7.0":
   version "0.7.1"
@@ -1518,7 +1559,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
   integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
 
-"@emotion/weak-memoize@^0.2.5":
+"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -5325,6 +5366,22 @@ babel-plugin-emotion@10.0.33:
   version "10.0.33"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz#ce1155dcd1783bbb9286051efee53f4e2be63e03"
   integrity sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.8.0"
+    "@emotion/memoize" "0.7.4"
+    "@emotion/serialize" "^0.11.16"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
+babel-plugin-emotion@^10.0.27:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz#a1fe3503cff80abfd0bdda14abd2e8e57a79d17d"
+  integrity sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@emotion/hash" "0.8.0"


### PR DESCRIPTION
After the emotion v11 upgrade(https://github.com/bumbag/bumbag-ui/commit/969ac0502d8304fbb9df7da4d09f6974a9619036), Google fonts haven't been working properly on Safari. 

Since the Medipass theme loads a Google font (Lato), you can see this issue in the Bumbag docs.

To fix this, I just changed bumbag to use `Global` from `@emotion/core` rather than `@emotion/react`.

## Before: 
![image](https://user-images.githubusercontent.com/40446421/124071461-b0b22280-da82-11eb-9cf7-fa79152514d8.png)

The Lato font is not being loaded
![image](https://user-images.githubusercontent.com/40446421/124071312-7b0d3980-da82-11eb-9d26-046f14da05ee.png)

## After:
![image](https://user-images.githubusercontent.com/40446421/124071429-a2fc9d00-da82-11eb-8833-9f5ef7292c3e.png)

The Lato font is now being loaded
![image](https://user-images.githubusercontent.com/40446421/124071281-7183d180-da82-11eb-8aa9-f2ecf2d3d187.png)